### PR TITLE
Dakkar changes

### DIFF
--- a/t/05.not-html.t
+++ b/t/05.not-html.t
@@ -1,0 +1,61 @@
+#!perl
+use Test::More;
+use strict;
+use warnings;
+
+use HTTP::Cookies;
+use HTTP::Request::Common;
+use HTTP::Status ':constants';
+use LWP::UserAgent;
+use Plack::Builder;
+use Plack::Test;
+use Plack::Session::State::Cookie;
+
+use FindBin::libs;
+use Test::XSRFBlock::App;
+use Test::XSRFBlock::Util ':all';
+
+# normal input
+my %app = %{ Test::XSRFBlock::App->setup_test_apps };
+
+for my $appname ('psgix.input.non-buffered', 'psgix.input.buffered') {
+    subtest $appname => sub {
+        my $ua = LWP::UserAgent->new;
+        $ua->cookie_jar( HTTP::Cookies->new );
+
+        test_psgi ua => $ua, app => $app{$appname}, client => sub {
+            my $cb  = shift;
+            my ($res, $h_cookie, $jar, $token);
+            $jar = $ua->cookie_jar;
+
+            $res = $cb->(GET "/csv");
+            is (
+                $res->code,
+                HTTP_OK,
+                sprintf(
+                    'GET %s returns HTTP_OK(%d)',
+                    $res->request->uri,
+                    HTTP_OK
+                )
+            );
+            $h_cookie = $res->header('Set-Cookie') || '';
+            is($h_cookie, '', 'Not trying to Set-Cookie on non-html');
+            # we should have no (previous) cookies floating around
+            $jar->extract_cookies($res);
+            unlike(
+                $jar->as_string,
+                qr{PSGI-XSRF-Token},
+                'no sign of PSGI-XSRF-Token in cookie jar',
+            );
+
+            unlike(
+                $res->content,
+                qr{xsrf_token},
+                'no token should have been added to the contents',
+            );
+        };
+    };
+}
+
+done_testing;
+

--- a/t/lib/Test/XSRFBlock/App.pm
+++ b/t/lib/Test/XSRFBlock/App.pm
@@ -58,6 +58,11 @@ my $form_localhost_port = <<FORM;
 </html>
 FORM
 
+my $csv_with_html_form = <<'CSV';
+a,b,c,d
+1,2,3,"<form action='/' method='post'>"
+CSV
+
 sub base_app {
     my $base_app = sub {
         my $req = Plack::Request->new(shift);
@@ -91,6 +96,7 @@ sub mapped_app {
         mount "/form/html-outside" => sub { [ HTTP_OK, [ 'Content-Type' => 'text/html' ], [ $form_outside ] ] };
         mount "/form/html-localhost" => sub { [ HTTP_OK, [ 'Content-Type' => 'text/html' ], [ $form_localhost ] ] };
         mount "/form/html-localhost-port" => sub { [ HTTP_OK, [ 'Content-Type' => 'text/html' ], [ $form_localhost_port ] ] };
+        mount "/csv" => sub { [ HTTP_OK, [ 'Content-type' => 'text/csv' ], [ $csv_with_html_form ] ] };
     };
 }
 


### PR DESCRIPTION
* allow changing the set of HTTP methods we check (e.g. to add `PUT`, `DELETE`, &c)
* allow changing the set of content types we check
* split code in smaller methods
* make the content type check *actually work*

If the application returned a non-HTML document which happened to contain a string that looked like a form, the middleware would happily inject `<input type="hidden" name="xsrf_token" value="ARRAY(...)">`

The `ARRAY` came from `cookie_handler` returning `$res` instead of a token.