### PR TITLE
avoid Data::Printer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+ - don't use Data::Printer (@dakkar) (#24)
 
 0.0.15    2018-07-24 13:44:11+01:00 Europe/London
  - fix contents_to_filter_regex (@dakkar) (#23)

--- a/t/03.request_header.t
+++ b/t/03.request_header.t
@@ -141,7 +141,14 @@ for my $appname ('psgix.input.non-buffered', 'psgix.input.buffered') {
 
 sub _debug_fail {
     my $res = shift;
-    use Data::Printer alias=>'splat'; diag $res->content; diag $res->code; diag splat($res->headers);
+    use Data::Dumper;
+    local $Data::Dumper::Indent   = 1;
+    local $Data::Dumper::Sortkeys = 1;
+    local $Data::Dumper::Terse    = 1;
+
+    diag $res->content;
+    diag $res->code;
+    diag Data::Dumper::Dumper($res->headers);
 }
 
 done_testing;


### PR DESCRIPTION
`Data::Printer` is a great module. But it's not *safe*: it executes `~/.dataprinter`
