### PR TITLE
Skip default error level logging "returning HTTP_FORBIDDEN" if `blocked` callback exists

### DIFF
--- a/lib/Plack/Middleware/XSRFBlock.pm
+++ b/lib/Plack/Middleware/XSRFBlock.pm
@@ -587,11 +587,11 @@ sub xsrf_detected {
         ? sprintf('XSRF detected [%s]', $args->{msg})
         : 'XSRF detected';
 
-    $self->log(error => "$msg, returning HTTP_FORBIDDEN");
-
     if (my $app_for_blocked = $self->blocked) {
         return $app_for_blocked->($env, $msg, app => $self->app);
     }
+
+    $self->log(error => "$msg, returning HTTP_FORBIDDEN");
 
     return [
         HTTP_FORBIDDEN,


### PR DESCRIPTION
If there is a `blocked` callback, it's entirely possible the returned response will not be 403, so logging it as an error can be confusing when the actual response the client receives is something else.

Thank you for considering the change.